### PR TITLE
Update requirements.txt email_validator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ flask
 flask_login
 flask_migrate
 flask_wtf
+email_validator
 flask_sqlalchemy
 gunicorn


### PR DESCRIPTION
WTForms 3.x now requires a separate email_validator package installed. Added to requirements.txt to enable successful load.